### PR TITLE
[Fix] protect factors in iron()

### DIFF
--- a/R/iron.R
+++ b/R/iron.R
@@ -14,21 +14,34 @@
 #' waffle_iron(mpg, aes_d(group = class))
 #'
 #' waffle_iron(mpg, aes_d(group = class), sample_size = 0.75)
-waffle_iron <- function(data, mapping, rows = 8, sample_size = 1, na.rm = T){
+#'
+#' waffle_iron(iris, "Species")
+waffle_iron <- function(data, mapping, rows = 8, sample_size = 1, na.rm = TRUE){
   # sample the data
-  if(!(sample_size>0 & sample_size <=1)){
-    stop("Please use a sample value between 0 and 1", call. = F)
+  if(sample_size != 1) {
+    if(!(sample_size>0 & sample_size <=1)){
+      stop("Please use a sample value between 0 and 1", call. = FALSE)
+    }
+    sample_rows <- sample(x = 1:nrow(data), size = (nrow(data) * sample_size))
+    data <- data[sample_rows,]
   }
-  sample_rows <- sample(x = 1:nrow(data), size = (nrow(data) * sample_size))
-  data <- data[sample_rows,]
+
+  # Get mapping
+  if(inherits(mapping, "character")) {
+    data$group <- data[[mapping]]
+  } else {
+    data <- aes_d_rename(data, mapping, c("group"))
+  }
+
   # create the waffle dataset
-  data <- aes_d_rename(data, mapping, c("group"))
   data <- data[order(data$group),]
   grid_data <- expand.grid(y = 1:rows, x = seq_len((ceiling(nrow(data) / rows))))
-  grid_data$group <- c(data$group, rep(NA, nrow(grid_data) - length(data$group)))
+  grid_data$group <- c(data$group, as.factor(rep(NA, nrow(grid_data) - length(data$group))))
+
   # deal with NAs
-  if(na.rm == T){
+  if(na.rm == TRUE){
     grid_data <- grid_data[!is.na(grid_data$group),]
   }
-  return(grid_data)
+
+  grid_data
 }


### PR DESCRIPTION
Hi @liamgilbey, this is a fairly small but IMO vital fix that:

1) protect factors and doesn't coerce them to numeric (previous behavior did change factor levels to 1, 2, 3 etc)
2) Allows `mapping` argument to be a character indicating the column to iron on (the `aes_d` logic is a bit clunky when something simple is desired, so this would increase the flexibility. Also with this feature it makes it easy to program with)

In general, this allows for a more streamlined syntax and flexible waffles where one can change the factor levels and the order of the colors.